### PR TITLE
Update reversion conditions in MIP-8 to match EIP-2929

### DIFF
--- a/MIPS/MIP-8.md
+++ b/MIPS/MIP-8.md
@@ -260,7 +260,7 @@ if current_state_growth[p] > net_state_growth[p] :
 	  net_state_growth[p]  = current_state_growth[p]
 ```
 
-During execution, if a call reverts, the counters `current_state_growth` and `net_state_growth` must revert to their values from before that call to maintain price consistency.
+During execution, if a call reverts, the counters `current_state_growth` and `net_state_growth` as well as sets `read_accessed_pages` and `write_accessed_pages` must revert to their values from before that call to maintain price consistency.
 
 ## Rationale
 


### PR DESCRIPTION
Expanded the effects of a call reverting to include 'read_accessed_pages' and 'write_accessed_pages' alongside the existing counters. This is assumed per EIP-2929 explicit rules, but worth to make explicit in MIP-8 as well