### PR TITLE
fix: redirect old URLs to new URLs after #53

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,18 @@
+{% comment %}
+  Dependency-free replacement for the jekyll-redirect-from plugin.
+
+  A page using this layout renders a static HTML stub that redirects the
+  browser to `page.redirect_to`. Used by the files under `redirects/` to keep
+  the pre-#53 `/MIPS/...` (uppercase) URLs alive after the folder was renamed
+  to `MIPs/`. Cool URLs don't change :)
+{% endcomment %}<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ page.redirect_to | absolute_url }}">
+  <script>location="{{ page.redirect_to | absolute_url }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ page.redirect_to | absolute_url }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ page.redirect_to | absolute_url }}">Click here if you are not redirected.</a>
+</html>

--- a/redirects/MIP-1-slash.md
+++ b/redirects/MIP-1-slash.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-1/
+redirect_to: /MIPs/MIP-1
+---

--- a/redirects/MIP-1.md
+++ b/redirects/MIP-1.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-1
+redirect_to: /MIPs/MIP-1
+---

--- a/redirects/MIP-10-slash.md
+++ b/redirects/MIP-10-slash.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-10/
+redirect_to: /MIPs/MIP-10
+---

--- a/redirects/MIP-10.md
+++ b/redirects/MIP-10.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-10
+redirect_to: /MIPs/MIP-10
+---

--- a/redirects/MIP-11-slash.md
+++ b/redirects/MIP-11-slash.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-11/
+redirect_to: /MIPs/MIP-11
+---

--- a/redirects/MIP-11.md
+++ b/redirects/MIP-11.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-11
+redirect_to: /MIPs/MIP-11
+---

--- a/redirects/MIP-12-slash.md
+++ b/redirects/MIP-12-slash.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-12/
+redirect_to: /MIPs/MIP-12
+---

--- a/redirects/MIP-12.md
+++ b/redirects/MIP-12.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-12
+redirect_to: /MIPs/MIP-12
+---

--- a/redirects/MIP-2-slash.md
+++ b/redirects/MIP-2-slash.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-2/
+redirect_to: /MIPs/MIP-2
+---

--- a/redirects/MIP-2.md
+++ b/redirects/MIP-2.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-2
+redirect_to: /MIPs/MIP-2
+---

--- a/redirects/MIP-3-slash.md
+++ b/redirects/MIP-3-slash.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-3/
+redirect_to: /MIPs/MIP-3
+---

--- a/redirects/MIP-3.md
+++ b/redirects/MIP-3.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-3
+redirect_to: /MIPs/MIP-3
+---

--- a/redirects/MIP-4-slash.md
+++ b/redirects/MIP-4-slash.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-4/
+redirect_to: /MIPs/MIP-4
+---

--- a/redirects/MIP-4.md
+++ b/redirects/MIP-4.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-4
+redirect_to: /MIPs/MIP-4
+---

--- a/redirects/MIP-5-slash.md
+++ b/redirects/MIP-5-slash.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-5/
+redirect_to: /MIPs/MIP-5
+---

--- a/redirects/MIP-5.md
+++ b/redirects/MIP-5.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-5
+redirect_to: /MIPs/MIP-5
+---

--- a/redirects/MIP-6-slash.md
+++ b/redirects/MIP-6-slash.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-6/
+redirect_to: /MIPs/MIP-6
+---

--- a/redirects/MIP-6.md
+++ b/redirects/MIP-6.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-6
+redirect_to: /MIPs/MIP-6
+---

--- a/redirects/MIP-7-slash.md
+++ b/redirects/MIP-7-slash.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-7/
+redirect_to: /MIPs/MIP-7
+---

--- a/redirects/MIP-7.md
+++ b/redirects/MIP-7.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-7
+redirect_to: /MIPs/MIP-7
+---

--- a/redirects/MIP-8-slash.md
+++ b/redirects/MIP-8-slash.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-8/
+redirect_to: /MIPs/MIP-8
+---

--- a/redirects/MIP-8.md
+++ b/redirects/MIP-8.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-8
+redirect_to: /MIPs/MIP-8
+---

--- a/redirects/MIP-9-slash.md
+++ b/redirects/MIP-9-slash.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-9/
+redirect_to: /MIPs/MIP-9
+---

--- a/redirects/MIP-9.md
+++ b/redirects/MIP-9.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /MIPS/MIP-9
+redirect_to: /MIPs/MIP-9
+---


### PR DESCRIPTION
This PR fixes a few dead links that are linked from many different places. Cool URLs don't change :)

@pdobacz apparently, GitHub doesn't update the diff for closed PRs.
Here's a version of https://github.com/monad-crypto/MIPs/pull/64#issuecomment-4969858929 that works without dependencies as there are also various other sites on the internet that used those old links.
E.g. all the mips links here:
https://themonadpulse.substack.com/i/196787768/mip-10-deterministic-raptorcast-design
or the reference here:
https://luma.com/9odj44ic

Don't hesitate to close this one, if you don't like the approach of keeping those redirects in the repository forever :)